### PR TITLE
Move FeatureExtensions to end of Login7 Packet + use full server name for Login7

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -873,7 +873,7 @@ export interface ConnectionOptions {
 interface RoutingData {
   server: string;
   port: number;
-  login7server: string;
+  instance: string;
 }
 
 /**
@@ -2485,7 +2485,7 @@ class Connection extends EventEmitter {
     }
 
     payload.hostname = this.config.options.workstationId || os.hostname();
-    payload.serverName = this.routingData ? this.routingData.login7server : this.config.server;
+    payload.serverName = this.routingData ? `${this.routingData.server}\\${this.routingData.instance}` : this.config.server;
     payload.appName = this.config.options.appName || 'Tedious';
     payload.libraryName = libraryName;
     payload.language = this.config.options.language;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -873,6 +873,7 @@ export interface ConnectionOptions {
 interface RoutingData {
   server: string;
   port: number;
+  login7server: string;
 }
 
 /**
@@ -2484,7 +2485,7 @@ class Connection extends EventEmitter {
     }
 
     payload.hostname = this.config.options.workstationId || os.hostname();
-    payload.serverName = this.routingData ? this.routingData.server : this.config.server;
+    payload.serverName = this.routingData ? this.routingData.login7server : this.config.server;
     payload.appName = this.config.options.appName || 'Tedious';
     payload.libraryName = libraryName;
     payload.language = this.config.options.language;

--- a/src/login7-payload.ts
+++ b/src/login7-payload.ts
@@ -251,15 +251,12 @@ class Login7Payload {
     }
 
     // (ibUnused / ibExtension): 2-byte
-    offset = fixedData.writeUInt16LE(dataOffset, offset);
+    const extensionOffsetHeaderOffset = offset;
+    offset = fixedData.writeUInt16LE(0, offset);
+
 
     // (cchUnused / cbExtension): 2-byte
-    const extensions = this.buildFeatureExt();
     offset = fixedData.writeUInt16LE(4, offset);
-    const extensionOffset = Buffer.alloc(4);
-    extensionOffset.writeUInt32LE(dataOffset += 4, 0);
-    dataOffset += extensions.length;
-    buffers.push(extensionOffset, extensions);
 
     // ibCltIntName: 2-byte
     offset = fixedData.writeUInt16LE(dataOffset, offset);
@@ -364,6 +361,13 @@ class Login7Payload {
     } else {
       fixedData.writeUInt32LE(0, offset);
     }
+
+    fixedData.writeUInt16LE(dataOffset, extensionOffsetHeaderOffset);
+
+    const extensions = this.buildFeatureExt();
+    const extensionOffset = Buffer.alloc(4);
+    extensionOffset.writeUInt32LE(dataOffset + 4, 0);
+    buffers.push(extensionOffset, extensions);
 
     const data = Buffer.concat(buffers);
     data.writeUInt32LE(data.length, 0);

--- a/src/token/handler.ts
+++ b/src/token/handler.ts
@@ -246,7 +246,7 @@ export class Login7TokenHandler extends TokenHandler {
   declare connection: Connection;
 
   declare fedAuthInfoToken: FedAuthInfoToken | undefined;
-  declare routingData: { server: string, port: number, login7server: string } | undefined;
+  declare routingData: { server: string, port: number, instance: string } | undefined;
 
   declare loginAckReceived: boolean;
 
@@ -337,10 +337,10 @@ export class Login7TokenHandler extends TokenHandler {
 
   onRoutingChange(token: RoutingEnvChangeToken) {
     // Removes instance name attached to the redirect url. E.g., redirect.db.net\instance1 --> redirect.db.net
-    const [ server ] = token.newValue.server.split('\\');
+    const [ server, instance ] = token.newValue.server.split('\\');
 
     this.routingData = {
-      server, port: token.newValue.port, login7server: token.newValue.server
+      server, port: token.newValue.port, instance
     };
   }
 

--- a/src/token/handler.ts
+++ b/src/token/handler.ts
@@ -246,7 +246,7 @@ export class Login7TokenHandler extends TokenHandler {
   declare connection: Connection;
 
   declare fedAuthInfoToken: FedAuthInfoToken | undefined;
-  declare routingData: { server: string, port: number } | undefined;
+  declare routingData: { server: string, port: number, login7server: string } | undefined;
 
   declare loginAckReceived: boolean;
 
@@ -340,7 +340,7 @@ export class Login7TokenHandler extends TokenHandler {
     const [ server ] = token.newValue.server.split('\\');
 
     this.routingData = {
-      server, port: token.newValue.port
+      server, port: token.newValue.port, login7server: token.newValue.server
     };
   }
 


### PR DESCRIPTION
1. Write FeatureExtensions to the end of the Login7 Packet matching the behavior of the go-mssqldb library. The header must still be written at the same time as it was previously. The value in the header is adjusted to reflect that FeatureExtensions now appear at the end of the packet
2. When receiving routing data from the server, save two separate strings `server` and `instance`. `server` removes the instance name from the redirect URL (used in TLS negotiation) while `instance` is needed for Login7