### PR TITLE
Add TraceID to Prelogin Message

### DIFF
--- a/src/prelogin-payload.ts
+++ b/src/prelogin-payload.ts
@@ -261,7 +261,7 @@ class PreloginPayload {
   }
 
   extractTraceId(offset: number) {
-    this.traceId = this.data.subarray(offset, 36);
+    this.traceId = this.data.subarray(offset, traceIdSize);
   }
 
   extractFedAuth(offset: number) {

--- a/src/prelogin-payload.ts
+++ b/src/prelogin-payload.ts
@@ -4,6 +4,7 @@ import WritableTrackingBuffer from './tracking-buffer/writable-tracking-buffer';
 import { randomBytes } from 'crypto';
 
 const optionBufferSize = 20;
+const traceIdSize = 36;
 
 const TOKEN = {
   VERSION: 0x00,
@@ -187,12 +188,10 @@ class PreloginPayload {
   }
 
   createTraceIdOption() {
-    const buffer = new WritableTrackingBuffer(36);
+    const buffer = new WritableTrackingBuffer(traceIdSize);
     // generate a random series of bytes to use as the TraceID
     // used for debugging purposes
-    for (let i = 0; i < 36; i++) {
-      buffer.writeUInt8(randomBytes(1)[0]);
-    }
+    buffer.writeBuffer(randomBytes(traceIdSize));
     return {
       token: TOKEN.TRACEID,
       data: buffer.data


### PR DESCRIPTION
Add TraceID to Prelogin message.

Despite the [documentation](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/60f56408-0188-4cd5-8b90-25c6f2423868?redirectedfrom=MSDN) saying that it's only for debugging purposes, submitting a prelogin without a TraceID now causes a connection error after TDS37.0.

For our purposes, we are not currently interested in the debugging ID, so I just generate a random series of bytes to make it work. We can consider making it a more traceable TraceID in the future